### PR TITLE
use pool cookie time instead of wall time

### DIFF
--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1585,6 +1585,26 @@ public:
   virtual cryptonote::blobdata get_txpool_tx_blob(const crypto::hash& txid, relay_category tx_category) const = 0;
 
   /**
+   * @brief load the mempool logical timestamp
+   *
+   * This timestamp is a means to partially order tx pool events. This value should only ever
+   * increase monotonically. Preferably, this value doesn't corellate with any real-life time.
+   *
+   * @return uint64_t the mempool logical timestamp, or 0 if not present
+   */
+  virtual uint64_t get_txpool_logical_timestamp() const = 0;
+
+  /**
+   * @brief save the mempool logical timestamp
+   *
+   * This timestamp is a means to partially order tx pool events. This value should only ever
+   * increase monotonically. Preferably, this value doesn't corellate with any real-life time.
+   *
+   * @param logical_timestamp the logical timestamp to save
+   */
+  virtual void set_txpool_logical_timestamp(uint64_t logical_timestamp) = 0;
+
+  /**
    * @brief Check if `tx_hash` relay status is in `category`.
    *
    * @param tx_hash hash of the transaction to lookup

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -292,6 +292,8 @@ public:
   virtual bool get_txpool_tx_meta(const crypto::hash& txid, txpool_tx_meta_t &meta) const;
   virtual bool get_txpool_tx_blob(const crypto::hash& txid, cryptonote::blobdata& bd, relay_category tx_category) const;
   virtual cryptonote::blobdata get_txpool_tx_blob(const crypto::hash& txid, relay_category tx_category) const;
+  virtual uint64_t get_txpool_logical_timestamp() const override;
+  virtual void set_txpool_logical_timestamp(uint64_t logical_timestamp) override;
   virtual uint32_t get_blockchain_pruning_seed() const;
   virtual bool prune_blockchain(uint32_t pruning_seed = 0);
   virtual bool update_pruning();

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -136,6 +136,8 @@ public:
   virtual bool get_txpool_tx_blob(const crypto::hash& txid, cryptonote::blobdata &bd, relay_category tx_category) const override { return false; }
   virtual uint64_t get_database_size() const override { return 0; }
   virtual cryptonote::blobdata get_txpool_tx_blob(const crypto::hash& txid, relay_category tx_category) const override { return ""; }
+  virtual uint64_t get_txpool_logical_timestamp() const override { return 0; }
+  virtual void set_txpool_logical_timestamp(uint64_t) override {}
   virtual bool for_all_txpool_txes(std::function<bool(const crypto::hash&, const cryptonote::txpool_tx_meta_t&, const cryptonote::blobdata_ref*)>, bool include_blob = false, relay_category category = relay_category::broadcasted) const override { return false; }
 
   virtual void add_block( const cryptonote::block& blk

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -5467,6 +5467,16 @@ cryptonote::blobdata Blockchain::get_txpool_tx_blob(const crypto::hash& txid, re
   return m_db->get_txpool_tx_blob(txid, tx_category);
 }
 
+uint64_t Blockchain::get_txpool_logical_timestamp() const
+{
+  return m_db->get_txpool_logical_timestamp();
+}
+
+void Blockchain::set_txpool_logical_timestamp(uint64_t logical_timestamp)
+{
+  m_db->set_txpool_logical_timestamp(logical_timestamp);
+}
+
 bool Blockchain::for_all_txpool_txes(std::function<bool(const crypto::hash&, const txpool_tx_meta_t&, const cryptonote::blobdata_ref*)> f, bool include_blob, relay_category tx_category) const
 {
   return m_db->for_all_txpool_txes(f, include_blob, tx_category);

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1051,6 +1051,8 @@ namespace cryptonote
     bool get_txpool_tx_meta(const crypto::hash& txid, txpool_tx_meta_t &meta) const;
     bool get_txpool_tx_blob(const crypto::hash& txid, cryptonote::blobdata &bd, relay_category tx_category) const;
     cryptonote::blobdata get_txpool_tx_blob(const crypto::hash& txid, relay_category tx_category) const;
+    uint64_t get_txpool_logical_timestamp() const;
+    void set_txpool_logical_timestamp(uint64_t logical_timestamp);
     bool for_all_txpool_txes(std::function<bool(const crypto::hash&, const txpool_tx_meta_t&, const cryptonote::blobdata_ref*)>, bool include_blob = false, relay_category tx_category = relay_category::broadcasted) const;
     bool txpool_tx_matches_category(const crypto::hash& tx_hash, relay_category category);
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1749,6 +1749,11 @@ namespace cryptonote
     return m_mempool.get_pool_info(start_time, include_sensitive_txes, max_tx_count, added_txs, remaining_added_txids, removed_txs, incremental);
   }
   //-----------------------------------------------------------------------------------------------
+  uint64_t core::get_txpool_logical_timestamp() const
+  {
+    return m_mempool.get_txpool_logical_timestamp();
+  }
+  //-----------------------------------------------------------------------------------------------
   bool core::get_pool_transaction_stats(struct txpool_stats& stats, bool include_sensitive_data) const
   {
     m_mempool.get_transaction_stats(stats, include_sensitive_data);

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -526,6 +526,13 @@ namespace cryptonote
       */
      bool get_pool_info(time_t start_time, bool include_sensitive_txes, size_t max_tx_count, std::vector<std::pair<crypto::hash, tx_memory_pool::tx_details>>& added_txs, std::vector<crypto::hash>& remaining_added_txids, std::vector<crypto::hash>& removed_txs, bool& incremental) const;
 
+     /**
+      * @copydoc tx_memory_pool::get_txpool_logical_timestamp
+      *
+      * @note see tx_memory_pool::get_txpool_logical_timestamp
+      */
+     uint64_t get_txpool_logical_timestamp() const;
+
     /**
       * @copydoc tx_memory_pool::get_transactions
       * @param include_sensitive_txes include private transactions

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -484,7 +484,14 @@ namespace cryptonote
      *
      * @return true on success, false on error
      */
-    bool get_pool_info(time_t start_time, bool include_sensitive, size_t max_tx_count, std::vector<std::pair<crypto::hash, tx_details>>& added_txs, std::vector<crypto::hash>& remaining_added_txids, std::vector<crypto::hash>& removed_txs, bool& incremental) const;
+    bool get_pool_info(uint64_t start_time, bool include_sensitive, size_t max_tx_count, std::vector<std::pair<crypto::hash, tx_details>>& added_txs, std::vector<crypto::hash>& remaining_added_txids, std::vector<crypto::hash>& removed_txs, bool& incremental) const;
+
+    /**
+     * @brief get a monotonically increasing counter which is used to order incremental pool events
+     *
+     * Do not assume that this counter value will be shared between mempool instances.
+     */
+    uint64_t get_txpool_logical_timestamp() const;
 
   private:
 
@@ -627,10 +634,10 @@ private:
     std::atomic<uint64_t> m_cookie; //!< incremented at each change
 
     // Info when transactions entered the pool, accessible by txid
-    std::unordered_map<crypto::hash, time_t> m_added_txs_by_id;
+    std::unordered_map<crypto::hash, uint64_t> m_added_txs_by_id;
 
     // Info at what time the pool started to track the adding of transactions
-    time_t m_added_txs_start_time;
+    uint64_t m_added_txs_start_time;
 
     struct removed_tx_info
     {
@@ -640,11 +647,11 @@ private:
 
     // Info about transactions that were removed from the pool, ordered by the time
     // of deletion
-    std::multimap<time_t, removed_tx_info> m_removed_txs_by_time;
+    std::multimap<uint64_t, removed_tx_info> m_removed_txs_by_time;
 
     // Info how far back in time the list of removed tx ids currently reaches
     // (it gets shorted periodically to prevent overflow)
-    time_t m_removed_txs_start_time;
+    uint64_t m_removed_txs_start_time;
 
     /**
      * @brief get an iterator to a transaction in the sorted container

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -598,7 +598,7 @@ namespace cryptonote
 
     CHECK_PAYMENT(req, res, 1);
 
-    res.daemon_time = (uint64_t)time(NULL);
+    res.daemon_time = m_core.get_txpool_logical_timestamp();
     // Always set daemon time, and set it early rather than late, as delivering some incremental pool
     // info twice because of slightly overlapping time intervals is no problem, whereas producing gaps
     // and never delivering something is
@@ -634,7 +634,7 @@ namespace cryptonote
 
       bool incremental;
       std::vector<std::pair<crypto::hash, tx_memory_pool::tx_details>> added_pool_txs;
-      bool success = m_core.get_pool_info((time_t)req.pool_info_since, allow_sensitive, max_tx_count, added_pool_txs, res.remaining_added_pool_txids, res.removed_pool_txids, incremental);
+      const bool success = m_core.get_pool_info(req.pool_info_since, allow_sensitive, max_tx_count, added_pool_txs, res.remaining_added_pool_txids, res.removed_pool_txids, incremental);
       if (success)
       {
         res.added_pool_txs.clear();
@@ -660,9 +660,6 @@ namespace cryptonote
           info.double_spend_seen = added_pool_tx.second.double_spend_seen;
           res.added_pool_txs.push_back(std::move(info));
         }
-      }
-      if (success)
-      {
         res.pool_info_extent = incremental ? COMMAND_RPC_GET_BLOCKS_FAST::INCREMENTAL : COMMAND_RPC_GET_BLOCKS_FAST::FULL;
       }
       else


### PR DESCRIPTION
Using `time(NULL)` to order incoming transactions has problems because the following could happen:
1. Wallet asks for current daemon time and daemon responds with time A
2. Daemon system time resynchronizes and falls backwards in time to time B (B < A)
3. Daemon add transaction T to mempool at time C (B < C < A)
4. Wallet asks for incremental changes since time A, daemon responds
5. Since C < A, transaction T is not sent to wallet
6. Wallet refresh is now in inconsistent state